### PR TITLE
Smooth operators fixes

### DIFF
--- a/src/steps/prospect/prospect-field-equals.ts
+++ b/src/steps/prospect/prospect-field-equals.ts
@@ -20,7 +20,7 @@ export class ProspectFieldEquals extends BaseStep implements StepInterface {
   }, {
     field: 'operator',
     type: FieldDefinition.Type.STRING,
-    description: 'Check Logic',
+    description: 'Check Logic (be, not be, contain, not contain, be greater than, or be less than)',
     optionality: FieldDefinition.Optionality.OPTIONAL,
   }, {
     field: 'expectedValue',

--- a/src/steps/prospect/prospect-field-equals.ts
+++ b/src/steps/prospect/prospect-field-equals.ts
@@ -47,13 +47,13 @@ export class ProspectFieldEquals extends BaseStep implements StepInterface {
         ]);
       // tslint:disable-next-line:triple-equals
       } else if (this.compare(operator, prospect[field], expectedValue)) {
-        return this.pass(this.operatorSuccessMessages[operator.replace(/\s/g, '').toLowerCase()], [
+        return this.pass(this.operatorSuccessMessages[], [
           field,
           expectedValue,
         ]);
       }
 
-      return this.fail(this.operatorFailMessages[operator.replace(/\s/g, '').toLowerCase()], [
+      return this.fail(this.operatorFailMessages[], [
         field,
         expectedValue,
         prospect[field],

--- a/src/steps/prospect/prospect-field-equals.ts
+++ b/src/steps/prospect/prospect-field-equals.ts
@@ -47,13 +47,13 @@ export class ProspectFieldEquals extends BaseStep implements StepInterface {
         ]);
       // tslint:disable-next-line:triple-equals
       } else if (this.compare(operator, prospect[field], expectedValue)) {
-        return this.pass(this.operatorSuccessMessages[], [
+        return this.pass(this.operatorSuccessMessages[operator], [
           field,
           expectedValue,
         ]);
       }
 
-      return this.fail(this.operatorFailMessages[], [
+      return this.fail(this.operatorFailMessages[operator], [
         field,
         expectedValue,
         prospect[field],


### PR DESCRIPTION
The `util` had a change in determining proper `pass/fail` messages as seen on:

https://github.com/run-crank/typescript-cog-utilities/blob/master/src/utils/compare.ts#L4

There are steps affected that still has the `.replace(/\s/g, '').toLowerCase()` code which removes all space and then therefore cannot be mapped to the updated pass fail messages in the `util` (which now contains space)


EDIT:
The last commit should fix #22 