### PR TITLE
List Membership Fixes

### DIFF
--- a/src/steps/listMembership/check-list-membership.ts
+++ b/src/steps/listMembership/check-list-membership.ts
@@ -93,7 +93,15 @@ export class CheckListMembership extends BaseStep implements StepInterface {
     } catch (e) {
       //// This means that the List ID provided does not exist
       if (e.message === 'Invalid ID') {
-        return this.error('No list found with ID %d', [listId]);
+        if (optInOut === 'not be a member of') {
+          return this.pass(
+            'Prospect %s is not a member of %d, as expected.',
+            [email, listId],
+            [prospectRecord],
+          );
+        }
+
+        return this.error('No list found with ID %d', [listId], [prospectRecord]);
       }
 
       return this.error('There was a problem checking list membership: %s', [e.toString()]);
@@ -102,19 +110,11 @@ export class CheckListMembership extends BaseStep implements StepInterface {
     listMembershipRecord = this.keyValue('listMembership', 'List Membership', listMembership);
 
     if (optInOut === 'not be a member of') {
-      if (!listMembership) {
-        return this.pass(
-          'Prospect %s is not a member of %d, as expected.',
-          [email, listId],
-          [prospectRecord],
-        );
-      } else {
-        return this.fail(
-          'Expected prospect %s to not be a member of list %d, but a list membership was found',
-          [email, listId],
-          [prospectRecord, listMembershipRecord],
-        );
-      }
+      return this.fail(
+        'Expected prospect %s to not be a member of list %d, but a list membership was found',
+        [email, listId],
+        [prospectRecord, listMembershipRecord],
+      );
     }
 
     if (optInOut === 'be opted in to') {

--- a/src/steps/listMembership/check-list-membership.ts
+++ b/src/steps/listMembership/check-list-membership.ts
@@ -78,69 +78,73 @@ export class CheckListMembership extends BaseStep implements StepInterface {
     const listId = stepData.listId;
     let listMembershipRecord;
     let prospectRecord;
+    let listMembership;
+
+    const prospect = await this.client.readByEmail(email);
+
+    if (!prospect) {
+      return this.error('No prospect found with email %s', [email]);
+    }
+
+    prospectRecord = this.keyValue('prospect', 'Checked Prospect', prospect);
 
     try {
-      const prospect = await this.client.readByEmail(email);
-
-      if (!prospect) {
-        return this.error('No prospect found with email %s', [email]);
-      }
-
-      prospectRecord = this.keyValue('prospect', 'Checked Prospect', prospect);
-
-      const listMembership = (await this.client.readByListIdAndProspectId(listId, prospect.id)).list_membership;
-
-      if (listMembership) {
-        listMembershipRecord = this.keyValue('listMembership', 'List Membership', listMembership);
-      }
-
-      if (optInOut === 'not be a member of') {
-        if (!listMembership) {
-          return this.pass(
-            'Prospect %s is not a member of %d, as expected.',
-            [email, listId],
-            [prospectRecord],
-          );
-        } else {
-          return this.fail(
-            'Expected prospect %s to not be a member of list %d, but a list membership was found',
-            [email, listId],
-            [prospectRecord, listMembershipRecord],
-          );
-        }
-      }
-
-      if (optInOut === 'be opted in to') {
-        if (listMembership.opted_out) {
-          return this.fail(
-            'Expected prospect %s to be opted in to list %d, but the prospect is opted out.',
-            [email, listId],
-            [prospectRecord, listMembershipRecord],
-          );
-        } else {
-          return this.pass(
-            'Prospect %s is opted in to list %s, as expected.',
-            [email, listId],
-            [prospectRecord, listMembershipRecord],
-          );
-        }
-      } else if (optInOut === 'be opted out of') {
-        if (listMembership.opted_out) {
-          return this.pass(
-            'Prospect %s is opted out of list %s, as expected.',
-            [email, listId],
-            [prospectRecord, listMembershipRecord],
-          );
-        } else {
-          return this.fail(
-            'Expected prospect %s to be opted out of list %d, but the prospect is opted in.',
-            [email, listId],
-            [prospectRecord, listMembershipRecord],
-          );
-        }
-      }
+      listMembership = (await this.client.readByListIdAndProspectId(listId, prospect.id)).list_membership;
     } catch (e) {
+      //// This means that the List ID provided does not exist
+      if (e.message === 'Invalid ID') {
+        return this.error('No list found with ID %d', [listId]);
+      }
+
       return this.error('There was a problem checking list membership: %s', [e.toString()]);
+    }
+
+    listMembershipRecord = this.keyValue('listMembership', 'List Membership', listMembership);
+
+    if (optInOut === 'not be a member of') {
+      if (!listMembership) {
+        return this.pass(
+          'Prospect %s is not a member of %d, as expected.',
+          [email, listId],
+          [prospectRecord],
+        );
+      } else {
+        return this.fail(
+          'Expected prospect %s to not be a member of list %d, but a list membership was found',
+          [email, listId],
+          [prospectRecord, listMembershipRecord],
+        );
+      }
+    }
+
+    if (optInOut === 'be opted in to') {
+      if (listMembership.opted_out) {
+        return this.fail(
+          'Expected prospect %s to be opted in to list %d, but the prospect is opted out.',
+          [email, listId],
+          [prospectRecord, listMembershipRecord],
+        );
+      } else {
+        return this.pass(
+          'Prospect %s is opted in to list %s, as expected.',
+          [email, listId],
+          [prospectRecord, listMembershipRecord],
+        );
+      }
+    } else if (optInOut === 'be opted out of') {
+      if (listMembership.opted_out) {
+        return this.pass(
+          'Prospect %s is opted out of list %s, as expected.',
+          [email, listId],
+          [prospectRecord, listMembershipRecord],
+        );
+      } else {
+        return this.fail(
+          'Expected prospect %s to be opted out of list %d, but the prospect is opted in.',
+          [email, listId],
+          [prospectRecord, listMembershipRecord],
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
As discussed earlier, the api call `rejects` when the supplied `listId` does not exist in pardot. This will fix the bug encountered when testing either:
 - `Not a member of` or `be opted in/out` of against a non-existing list. The not a member should pass, and opted in/out should fail when the step is ran using a non-existing `listId`
