### PR TITLE
Removed excess parenthesis from check list membership

### DIFF
--- a/src/steps/listMembership/check-list-membership.ts
+++ b/src/steps/listMembership/check-list-membership.ts
@@ -4,7 +4,7 @@ import { Step, RunStepResponse, FieldDefinition, StepDefinition, RecordDefinitio
 export class CheckListMembership extends BaseStep implements StepInterface {
 
   protected stepName: string = 'Check Pardot List Membership';
-  protected stepExpression: string = 'the (?<email>.+) pardot prospect should (?<optInOut>(be opted in to|be opted out of|not be a member of)) list (?<listId>.+)';
+  protected stepExpression: string = 'the (?<email>.+) pardot prospect should (?<optInOut>be opted in to|be opted out of|not be a member of) list (?<listId>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
   protected expectedFields: Field[] = [{
     field: 'email',

--- a/test/steps/prospect/check-list-membership.ts
+++ b/test/steps/prospect/check-list-membership.ts
@@ -28,7 +28,7 @@ describe('CheckListMembership', () => {
       const stepDef: StepDefinition = stepUnderTest.getDefinition();
       expect(stepDef.getStepId()).to.equal('CheckListMembership');
       expect(stepDef.getName()).to.equal('Check Pardot List Membership');
-      expect(stepDef.getExpression()).to.equal('the (?<email>.+) pardot prospect should (?<optInOut>(be opted in to|be opted out of|not be a member of)) list (?<listId>.+)');
+      expect(stepDef.getExpression()).to.equal('the (?<email>.+) pardot prospect should (?<optInOut>be opted in to|be opted out of|not be a member of) list (?<listId>.+)');
       expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
     });
 


### PR DESCRIPTION
Removed excess parenthesis for allowing specific values to the `optInOut` input. Checked other cogs that use the same pattern to allow certain values that proves an additional parenthesis is not necessary.