### PR TITLE
fixed error handling when prospect email does not exist

### DIFF
--- a/src/steps/listMembership/check-list-membership.ts
+++ b/src/steps/listMembership/check-list-membership.ts
@@ -80,15 +80,11 @@ export class CheckListMembership extends BaseStep implements StepInterface {
     let prospectRecord;
     let listMembership;
 
-    const prospect = await this.client.readByEmail(email);
-
-    if (!prospect) {
-      return this.fail('No prospect found with email %s', [email]);
-    }
-
-    prospectRecord = this.keyValue('prospect', 'Checked Prospect', prospect);
-
     try {
+      const prospect = await this.client.readByEmail(email);
+
+      prospectRecord = this.keyValue('prospect', 'Checked Prospect', prospect);
+
       listMembership = (await this.client.readByListIdAndProspectId(listId, prospect.id)).list_membership;
     } catch (e) {
       //// This means that the List ID provided does not exist
@@ -102,6 +98,10 @@ export class CheckListMembership extends BaseStep implements StepInterface {
         }
 
         return this.fail('No list found with ID %d', [listId], [prospectRecord]);
+      }
+
+      else if (e.response.data.err === 'Invalid prospect email address') {
+        return this.fail('No prospect found with email %s', [email]);
       }
 
       return this.error('There was a problem checking list membership: %s', [e.toString()]);

--- a/src/steps/listMembership/check-list-membership.ts
+++ b/src/steps/listMembership/check-list-membership.ts
@@ -88,7 +88,7 @@ export class CheckListMembership extends BaseStep implements StepInterface {
       listMembership = (await this.client.readByListIdAndProspectId(listId, prospect.id)).list_membership;
     } catch (e) {
       //// This means that the List ID provided does not exist
-      if (e.response.data.err === 'Invalid ID') {
+      if (e?.response?.data?.err === 'Invalid ID') {
         if (optInOut === 'not be a member of') {
           return this.pass(
             'Prospect %s is not a member of %d, as expected.',
@@ -98,8 +98,8 @@ export class CheckListMembership extends BaseStep implements StepInterface {
         }
 
         return this.fail('No list found with ID %d', [listId], [prospectRecord]);
-      } else if (e.response.data.err === 'Invalid prospect email address') {
-        return this.fail('No prospect found with email %s', [email]);
+      } else if (e?.response?.data?.err === 'Invalid prospect email address') {
+        return this.error('No prospect found with email %s', [email]);
       }
 
       return this.error('There was a problem checking list membership: %s', [e.toString()]);

--- a/src/steps/listMembership/check-list-membership.ts
+++ b/src/steps/listMembership/check-list-membership.ts
@@ -98,9 +98,7 @@ export class CheckListMembership extends BaseStep implements StepInterface {
         }
 
         return this.fail('No list found with ID %d', [listId], [prospectRecord]);
-      }
-
-      else if (e.response.data.err === 'Invalid prospect email address') {
+      } else if (e.response.data.err === 'Invalid prospect email address') {
         return this.fail('No prospect found with email %s', [email]);
       }
 

--- a/src/steps/prospect/prospect-field-equals.ts
+++ b/src/steps/prospect/prospect-field-equals.ts
@@ -80,11 +80,9 @@ export class ProspectFieldEquals extends BaseStep implements StepInterface {
     } catch (e) {
       if (e instanceof util.UnknownOperatorError) {
         return this.error('%s Please provide one of: %s', [e.message, baseOperators.join(', ')]);
-      }
-      else if (e instanceof util.InvalidOperandError) {
+      } else if (e instanceof util.InvalidOperandError) {
         return this.error('There was an error checking the prospect field: %s', [e.message]);
-      }
-      else if (e.response.data.err === 'Invalid prospect email address') {
+      } else if (e.response.data.err === 'Invalid prospect email address') {
         return this.fail('No prospect found with email %s', [email]);
       }
       return this.error('There was an error checking the prospect field: %s', [e.message]);

--- a/src/steps/prospect/prospect-field-equals.ts
+++ b/src/steps/prospect/prospect-field-equals.ts
@@ -66,10 +66,6 @@ export class ProspectFieldEquals extends BaseStep implements StepInterface {
     try {
       const prospect = await this.client.readByEmail(email);
 
-      if (!prospect) {
-        return this.fail('No prospect found with email %s', [email]);
-      }
-
       const prospectRecord = this.keyValue('prospect', 'Checked Prospect', prospect);
 
       if (!prospect.hasOwnProperty(field)) {
@@ -85,8 +81,11 @@ export class ProspectFieldEquals extends BaseStep implements StepInterface {
       if (e instanceof util.UnknownOperatorError) {
         return this.error('%s Please provide one of: %s', [e.message, baseOperators.join(', ')]);
       }
-      if (e instanceof util.InvalidOperandError) {
+      else if (e instanceof util.InvalidOperandError) {
         return this.error('There was an error checking the prospect field: %s', [e.message]);
+      }
+      else if (e.response.data.err === 'Invalid prospect email address') {
+        return this.fail('No prospect found with email %s', [email]);
       }
       return this.error('There was an error checking the prospect field: %s', [e.message]);
     }

--- a/src/steps/prospect/prospect-field-equals.ts
+++ b/src/steps/prospect/prospect-field-equals.ts
@@ -82,8 +82,8 @@ export class ProspectFieldEquals extends BaseStep implements StepInterface {
         return this.error('%s Please provide one of: %s', [e.message, baseOperators.join(', ')]);
       } else if (e instanceof util.InvalidOperandError) {
         return this.error('There was an error checking the prospect field: %s', [e.message]);
-      } else if (e.response.data.err === 'Invalid prospect email address') {
-        return this.fail('No prospect found with email %s', [email]);
+      } else if (e?.response?.data?.err === 'Invalid prospect email address') {
+        return this.error('No prospect found with email %s', [email]);
       }
       return this.error('There was an error checking the prospect field: %s', [e.message]);
     }

--- a/test/steps/prospect/check-list-membership.ts
+++ b/test/steps/prospect/check-list-membership.ts
@@ -56,7 +56,7 @@ describe('CheckListMembership', () => {
 
     describe('Prospect does not exist', () => {
       beforeEach(() => {
-        clientWrapperStub.readByEmail.returns(Promise.resolve(undefined));
+        clientWrapperStub.readByEmail.throws('Invalid prospect email address');
         protoStep.setData(Struct.fromJavaScript({
           email: 'invalid@thisisjust.atomatest.com',
           optInOut: 'not be a member of',
@@ -66,7 +66,7 @@ describe('CheckListMembership', () => {
 
       it('should respond with error', async () => {
         const response = await stepUnderTest.executeStep(protoStep);
-        expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+        expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
       });
     });
 

--- a/test/steps/prospect/prospect-field-equals.ts
+++ b/test/steps/prospect/prospect-field-equals.ts
@@ -178,12 +178,12 @@ describe('ProspectFieldEqualsStep', () => {
       };
       beforeEach(() => {
         protoStep.setData(Struct.fromJavaScript(expectedValues));
-        clientWrapperStub.readByEmail.returns(Promise.resolve(undefined));
+        clientWrapperStub.readByEmail.throws('Invalid prospect email address');
       });
 
       it('should respond with error', async () => {
         const response = await stepUnderTest.executeStep(protoStep);
-        expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+        expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
       });
     });
 


### PR DESCRIPTION
When no prospect exists with the provided email, we now correctly report the error instead of throwing a 400